### PR TITLE
Fix "Too Many Args" Error in SSH Bruteforce Threading Script

### DIFF
--- a/Chapter 05/ssh-brute-force-threded.py
+++ b/Chapter 05/ssh-brute-force-threded.py
@@ -47,7 +47,7 @@ letters_list = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQSTUVWXYZ1234567890!@#
 
 
 for i in bruteforce_list(letters_list, PASS_SIZE):
-    t = threading.Thread(target=attempt, args=(i))
+    t = threading.Thread(target=attempt, args=(i,))
     t.start()
     time.sleep(0.3)
 


### PR DESCRIPTION
Fix ssh-bruteforce-threded.py script to allow password guesses greater than 1 character. 
